### PR TITLE
Add code so tutorial accounts for adaptive batching

### DIFF
--- a/content/tutorials/xgboost_deployment.md
+++ b/content/tutorials/xgboost_deployment.md
@@ -39,10 +39,10 @@ watchlist = [(dtrain, 'train')]
 num_round = 2
 bst = xgb.train(param, dtrain, num_round, watchlist)
 ```
-We also must define our predict function for our model. In order to deploy the XGBoost model to Clipper, we define a closure that references the XGBoost model. Clipper's model deployer will automatically track down everything that is referenced in the closure (including the XGBoost model), and include it in the model container.
+We also must define our predict function for our model. In order to deploy the XGBoost model to Clipper, we define a closure that references the XGBoost model. Clipper's model deployer will automatically track down everything that is referenced in the closure (including the XGBoost model), and include it in the model container. We loop through every element in the batch to account for Clipper's adaptive batching, which adds duplicates of requests to batches to figure out the optimal batch size for a model container.
 ```python
 def predict(xs):
-    return [str(bst.predict(xgb.DMatrix(xs)))]
+    return [str(bst.predict(xgb.DMatrix(x))) for x in xs]
 ```
 Now that we have a model, as well as a predict function, we must deploy our model container. We will use a `python_closure_container`, and install the `xgboost` module using `pip`.
 ```python

--- a/content/tutorials/xgboost_deployment.md
+++ b/content/tutorials/xgboost_deployment.md
@@ -39,7 +39,7 @@ watchlist = [(dtrain, 'train')]
 num_round = 2
 bst = xgb.train(param, dtrain, num_round, watchlist)
 ```
-We also must define our predict function for our model. In order to deploy the XGBoost model to Clipper, we define a closure that references the XGBoost model. Clipper's model deployer will automatically track down everything that is referenced in the closure (including the XGBoost model), and include it in the model container. We loop through every element in the batch to account for Clipper's adaptive batching, which adds duplicates of requests to batches to figure out the optimal batch size for a model container.
+We also must define our predict function for our model. In order to deploy the XGBoost model to Clipper, we define a closure that references the XGBoost model. Clipper's model deployer will automatically track down everything that is referenced in the closure (including the XGBoost model), and include it in the model container. We loop through every element in the batch to account for Clipper's adaptive batching, which may add duplicates of requests to batches to figure out the optimal batch size for a model container. (For more info on adaptive batching, check out this [link](https://docs.google.com/presentation/d/12FLuE6HRnindJOxK_iy7pf8piC6SKR3KwDy-eNP0vlg/edit?usp=sharing))
 ```python
 def predict(xs):
     return [str(bst.predict(xgb.DMatrix(x))) for x in xs]


### PR DESCRIPTION
Old tutorial crashes when Clipper tries adaptive batching. Added code so it doesn't, as well as a brief explanation within the tutorial for why that code is there.